### PR TITLE
fix parse slash command

### DIFF
--- a/app/api/v1/slacks.rb
+++ b/app/api/v1/slacks.rb
@@ -26,7 +26,7 @@ module Slacks
         end
         post 'send' do
           st_params = strong_params(params).permit(:team_id, :user_id, :text)
-          if /@(?<receiver_id>.+)\|.+\s(?<thx>.+)\s(?<comment>.+)/ =~ st_params[:text]
+          if /@(?<receiver_id>.+)\|.+[\s　](?<thx>\d+)[\s　](?<comment>.+)/ =~ st_params[:text]
             receiver = User.find_by!(slack_user_id: receiver_id, slack_team_id: st_params[:team_id])
             sender = User.find_by!(slack_user_id: st_params[:user_id], slack_team_id: st_params[:team_id])
             if sender == receiver


### PR DESCRIPTION
## 背景
コメントに半角文字を使うとポイントが送れない問題があった
https://github.com/sashiyama/thx/issues/12

## 概要
以下の場合でも正確にパースできるようにした

- コメントに半角文字を含んでいる
- slashコマンドの区切りに半角スペースではなく、全角スペースを使用している

## 動作確認
